### PR TITLE
Made nav toggleable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -51,12 +51,32 @@ nav {
   height: 100vh;
   padding: 5px 15px;
   width: 250px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 450;
 }
 
 nav ul {
+  margin-left: 5px;
   padding-bottom: 50px;
   list-style: none;
   padding-left: 0px;
+}
+
+#navbtn {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  padding-top:10px;
+  padding-bottom:10px;
+  z-index: 451;
+  writing-mode: vertical-lr;
+  cursor: pointer;
+  color: #ffff;
+	background-color: #c33;
+	border-radius: 0.3em;
+	box-shadow: inset 0 0.2em 0 rgba(0,0,0,0.3);
 }
 
 /* Utility to hide things when small, also shrink sidebar */

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="css/switch.css" />
   </head>
   <body>
+    <div id="navbtn">Hide Nav</div>
     <nav>
       <header>
           <h1 class='nashviva'>NashViva!</h1>

--- a/js/main.js
+++ b/js/main.js
@@ -86,8 +86,8 @@ $(document).ready(function () {
     This center and zoom doesn't capture the entire box, but includes
     all of the points in our datasets without a lot of blank space.
   */
-  const map = L.map('map',{
-    "zoomControl":false
+  const map = L.map('map', {
+    'zoomControl': false
   }).setView(
     // center and zoom
     [36.165818, -86.784245],
@@ -100,8 +100,8 @@ $(document).ready(function () {
     when the nav is visible.
   */
   L.control.zoom({
-    "position":"topright"
-  }).addTo(map);
+    'position': 'topright'
+  }).addTo(map)
 
   // create the layer for the map from MapQuest
   L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
@@ -136,13 +136,13 @@ $(document).ready(function () {
       input.prop('disabled', false)
     })
   })
-  $('#navbtn').on("click", function(){
-    var navbarEl = $("nav");
-    navbarEl.toggle();
-    if (navbarEl.is(":visible")) {
-      $(this).text("Hide Nav");
+  $('#navbtn').on('click', function () {
+    let navbarEl = $('nav')
+    navbarEl.toggle()
+    if (navbarEl.is(':visible')) {
+      $(this).text('Hide Nav')
     } else {
-      $(this).text("Show Nav");
+      $(this).text('Show Nav')
     }
   })
 })

--- a/js/main.js
+++ b/js/main.js
@@ -26,7 +26,7 @@ const datasets = [
   {
     icon: 'wifi',
     markers: [],
-    index: 14,
+    index: 11,
     name: 'WiFi',
     url: 'https://data.nashville.gov/api/views/4ugp-s85t/rows.json'
   },
@@ -86,11 +86,22 @@ $(document).ready(function () {
     This center and zoom doesn't capture the entire box, but includes
     all of the points in our datasets without a lot of blank space.
   */
-  const map = L.map('map').setView(
+  const map = L.map('map',{
+    "zoomControl":false
+  }).setView(
     // center and zoom
     [36.165818, -86.784245],
     12
   )
+
+  /*
+    The nav is overlayed on top of the map so the
+    zoom buttons get in the way if they're on the top left
+    when the nav is visible.
+  */
+  L.control.zoom({
+    "position":"topright"
+  }).addTo(map);
 
   // create the layer for the map from MapQuest
   L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
@@ -124,5 +135,14 @@ $(document).ready(function () {
       input.click(() => setMarkersFor(map, points, dataset.markers, icon))
       input.prop('disabled', false)
     })
+  })
+  $('#navbtn').on("click", function(){
+    var navbarEl = $("nav");
+    navbarEl.toggle();
+    if (navbarEl.is(":visible")) {
+      $(this).text("Hide Nav");
+    } else {
+      $(this).text("Show Nav");
+    }
   })
 })


### PR DESCRIPTION
Added a small button to make the navigation toggleable. I made the navigation overlay on top of the map, which seemed to work better than making the map wider / narrower when the nav was hidden or made visible. The zoom controls didn't work well with the left nav overlayed, so I moved them to the right of the screen.
![nav-toggle](https://user-images.githubusercontent.com/9260712/33511763-3b26813e-d6e7-11e7-819c-0bbca0b20d71.png)
